### PR TITLE
Juggalo style

### DIFF
--- a/cards/Boombox Blast.json
+++ b/cards/Boombox Blast.json
@@ -1,0 +1,46 @@
+{
+  "name": "Boombox Blast",
+  "optional": [
+    {
+      "effects": [
+        {
+          "amount": "1",
+          "axis": "Poise",
+          "player": 0
+        },
+        {
+          "amount": "3",
+          "player": null,
+          "mechanic": "Block"
+        }
+      ],
+      "requirements": [
+        {
+          "id": 100,
+          "axis": "Moving",
+          "player": 0
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "axis": "Standing",
+      "player": 2
+    }
+  ],
+  "effects": [
+    {
+      "amount": "5",
+      "axis": "Damage",
+      "player": 1
+    }
+  ],
+  "tagObjs": [],
+  "tags": [],
+  "priority": 5
+}

--- a/cards/Bury the Hatchet.json
+++ b/cards/Bury the Hatchet.json
@@ -1,0 +1,54 @@
+{
+  "name": "Bury the Hatchet",
+  "optional": [
+    {
+      "effects": [
+        {
+          "amount": "10",
+          "axis": "Damage",
+          "player": 1
+        }
+      ],
+      "requirements": [
+        {
+          "id": 75,
+          "axis": "Not Anticipating",
+          "player": 1
+        },
+        {
+          "id": 74,
+          "axis": "Still",
+          "player": 1
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "axis": "Anticipating",
+      "player": 0
+    },
+    {
+      "axis": "Standing",
+      "player": 0
+    },
+    {
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "amount": "15",
+      "axis": "Damage",
+      "player": 1
+    }
+  ],
+  "tagObjs": [],
+  "priority": 8,
+  "tags": []
+}

--- a/cards/Evil Clown Laughter.json
+++ b/cards/Evil Clown Laughter.json
@@ -1,0 +1,65 @@
+{
+  "name": "Evil Clown Laughter",
+  "optional": [
+    {
+      "effects": [
+        {
+          "amount": "5",
+          "axis": "Damage",
+          "player": 1
+        }
+      ],
+      "requirements": [
+        {
+          "id": 55,
+          "axis": "Unbalanced",
+          "player": 1
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "axis": "Standing",
+      "player": 2
+    },
+    {
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "amount": "2",
+      "axis": "Poise",
+      "player": 0
+    },
+    {
+      "mechanicEffects": [
+        {
+          "amount": "2",
+          "axis": "Damage",
+          "player": 1
+        }
+      ],
+      "amount": "spooky",
+      "mechanic": "Enhance"
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 51
+    }
+  ],
+  "priority": 6,
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ]
+}

--- a/cards/Face Paint.json
+++ b/cards/Face Paint.json
@@ -1,0 +1,66 @@
+{
+  "name": "Face Paint",
+  "optional": [
+    {
+      "effects": [
+        {
+          "amount": "2",
+          "axis": "Poise",
+          "player": 0
+        }
+      ],
+      "requirements": [
+        {
+          "id": 7,
+          "axis": "Close",
+          "player": 2
+        },
+        {
+          "id": 10,
+          "axis": "Moving",
+          "player": 0
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Not Grappled",
+      "player": 2
+    },
+    {
+      "axis": "Standing",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "mechanicEffects": [
+        {
+          "amount": "1",
+          "axis": "Lose Poise",
+          "player": 1
+        }
+      ],
+      "amount": "spooky",
+      "mechanic": "Enhance"
+    },
+    {
+      "amount": "2",
+      "player": 0,
+      "mechanic": "Setup"
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 11
+    }
+  ],
+  "priority": 6,
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ]
+}

--- a/cards/Gathering of Clowns.json
+++ b/cards/Gathering of Clowns.json
@@ -1,0 +1,61 @@
+{
+  "name": "Gathering of Clowns",
+  "optional": [],
+  "requirements": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "axis": "Standing",
+      "player": 0
+    },
+    {
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "amount": "2",
+      "axis": "Lose Poise",
+      "player": 1
+    },
+    {
+      "mechanicRequirements": [
+        {
+          "axis": "Close",
+          "player": 2
+        },
+        {
+          "axis": "Moving",
+          "player": 0
+        }
+      ],
+      "mechanicEffects": [
+        {
+          "amount": "2",
+          "axis": "Poise",
+          "player": 2
+        }
+      ],
+      "mechanic": "Focus"
+    },
+    {
+      "amount": "2",
+      "mechanic": "Setup"
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 114
+    }
+  ],
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ],
+  "priority": 5
+}

--- a/cards/Head Spin.json
+++ b/cards/Head Spin.json
@@ -1,0 +1,40 @@
+{
+  "name": "Head Spin",
+  "optional": [
+    {
+      "effects": [
+        {
+          "axis": "Standing",
+          "player": 0
+        }
+      ],
+      "requirements": [
+        {
+          "id": 33,
+          "axis": "Prone",
+          "player": 0
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Not Grappled",
+      "player": 2
+    }
+  ],
+  "effects": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "amount": "3",
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "tagObjs": [],
+  "priority": 5,
+  "tags": []
+}

--- a/cards/Horror-Core Mosh Pit.json
+++ b/cards/Horror-Core Mosh Pit.json
@@ -1,0 +1,58 @@
+{
+  "name": "Horror-Core Mosh Pit",
+  "optional": [],
+  "requirements": [
+    {
+      "axis": "Not Grappled",
+      "player": 2
+    },
+    {
+      "axis": "Balanced",
+      "player": 0
+    },
+    {
+      "axis": "Not Anticipating",
+      "player": 1
+    }
+  ],
+  "effects": [
+    {
+      "amount": "2",
+      "axis": "Poise",
+      "player": 2
+    },
+    {
+      "mechanicRequirements": [
+        {
+          "axis": "Balanced",
+          "player": 2
+        }
+      ],
+      "mechanicEffects": [
+        {
+          "axis": "Moving",
+          "player": 2,
+          "amount": 2
+        },
+        {
+          "amount": "3",
+          "player": 2,
+          "mechanic": "Block"
+        }
+      ],
+      "mechanic": "Focus"
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 86
+    }
+  ],
+  "priority": 4,
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ]
+}

--- a/cards/Psycho Babble.json
+++ b/cards/Psycho Babble.json
@@ -1,0 +1,55 @@
+{
+  "name": "Psycho Babble",
+  "optional": [
+    {
+      "effects": [
+        {
+          "amount": "6",
+          "axis": "Damage",
+          "player": 1
+        }
+      ],
+      "requirements": [
+        {
+          "id": 64,
+          "axis": "Anticipating",
+          "player": 0
+        },
+        {
+          "id": 62,
+          "axis": "Standing",
+          "player": 0
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "amount": "2",
+      "axis": "Lose Poise",
+      "player": 1
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 66
+    }
+  ],
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ],
+  "priority": 5
+}

--- a/cards/Spray Faygo.json
+++ b/cards/Spray Faygo.json
@@ -1,0 +1,45 @@
+{
+  "name": "Spray Faygo",
+  "optional": [
+    {
+      "effects": [
+        {
+          "axis": "Standing",
+          "player": 0
+        }
+      ],
+      "requirements": [
+        {
+          "id": 92,
+          "axis": "Balanced",
+          "player": 0
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Not Grappled",
+      "player": 2
+    },
+    {
+      "axis": "Not Anticipating",
+      "player": 1
+    }
+  ],
+  "effects": [
+    {
+      "axis": "Moving",
+      "player": 2,
+      "amount": 2
+    },
+    {
+      "amount": "4",
+      "player": 2,
+      "mechanic": "Block"
+    }
+  ],
+  "tagObjs": [],
+  "priority": 7,
+  "tags": []
+}

--- a/cards/Stab to Death.json
+++ b/cards/Stab to Death.json
@@ -1,0 +1,74 @@
+{
+  "name": "Stab to Death",
+  "optional": [],
+  "requirements": [
+    {
+      "axis": "Close",
+      "player": 2
+    },
+    {
+      "axis": "Anticipating",
+      "player": 0
+    },
+    {
+      "axis": "Standing",
+      "player": 0
+    },
+    {
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "amount": "5",
+      "axis": "Damage",
+      "player": 1
+    },
+    {
+      "axis": "Standing",
+      "player": 0
+    },
+    {
+      "axis": "Moving",
+      "player": 0,
+      "amount": 2
+    },
+    {
+      "mechanicRequirements": [
+        {
+          "axis": "Close",
+          "player": 2
+        },
+        {
+          "axis": "Standing",
+          "player": 0
+        },
+        {
+          "axis": "Moving",
+          "player": 0
+        }
+      ],
+      "mechanicEffects": [
+        {
+          "amount": "5",
+          "axis": "Damage",
+          "player": 1
+        }
+      ],
+      "mechanic": "Focus"
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 134
+    }
+  ],
+  "priority": 6,
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ]
+}

--- a/cards/Whoop Whoop!.json
+++ b/cards/Whoop Whoop!.json
@@ -1,0 +1,69 @@
+{
+  "name": "Whoop Whoop!",
+  "optional": [
+    {
+      "effects": [
+        {
+          "amount": "2",
+          "axis": "Lose Poise",
+          "player": 1
+        }
+      ],
+      "requirements": [
+        {
+          "id": 44,
+          "axis": "Close",
+          "player": 2
+        }
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "axis": "Not Grappled",
+      "player": 2
+    },
+    {
+      "axis": "Standing",
+      "player": 0
+    },
+    {
+      "axis": "Moving",
+      "player": 0
+    }
+  ],
+  "effects": [
+    {
+      "amount": "4",
+      "mechanic": "Block"
+    },
+    {
+      "mechanicEffects": [
+        {
+          "amount": "1",
+          "axis": "Poise",
+          "player": 0
+        },
+        {
+          "axis": "Moving",
+          "player": 0,
+          "amount": 2
+        }
+      ],
+      "amount": "spooky",
+      "mechanic": "Enhance"
+    }
+  ],
+  "tagObjs": [
+    {
+      "value": "spooky",
+      "id": 38
+    }
+  ],
+  "priority": 7,
+  "tags": [
+    {
+      "value": "spooky"
+    }
+  ]
+}

--- a/server/styles/index.ts
+++ b/server/styles/index.ts
@@ -17,6 +17,7 @@ import { unstoppableStyle } from './unstoppable';
 import { newKidStyle } from './newKid';
 import { monkStyle } from './monk';
 import { rogueStyle } from './rogue';
+import { juggaloStyle } from './juggalo';
 import { ropeADopeStyle } from './ropeADope';
 import { workTheBodyStyle } from './workTheBody';
 import { genericStyle } from './generic';
@@ -41,6 +42,7 @@ const allStyles: FightingStyle[] = [
     newKidStyle,
     monkStyle,
     rogueStyle,
+    juggaloStyle,
     ropeADopeStyle,
     workTheBodyStyle,
     barbarianStyle,

--- a/server/styles/juggalo.ts
+++ b/server/styles/juggalo.ts
@@ -1,0 +1,19 @@
+import { FightingStyle } from "./interfaces";
+
+export const juggaloStyle: FightingStyle = {
+    name: 'Juggalo',
+    description: "We all family, whoop whoop!",
+    cards: [
+        "Stab to Death",
+        "Face Paint",
+        "Bury the Hatchet",
+        "Head Spin",
+        "Spray Faygo",
+        "Horror-Core Mosh Pit",
+        "Whoop Whoop!",
+        "Evil Clown Laughter",
+        "Psycho Babble",
+        "Boombox Blast",
+        "Gathering of Clowns",
+    ]
+}

--- a/serverBuild/styles/index.js
+++ b/serverBuild/styles/index.js
@@ -18,6 +18,7 @@ const unstoppable_1 = require("./unstoppable");
 const newKid_1 = require("./newKid");
 const monk_1 = require("./monk");
 const rogue_1 = require("./rogue");
+const juggalo_1 = require("./juggalo");
 const ropeADope_1 = require("./ropeADope");
 const workTheBody_1 = require("./workTheBody");
 const generic_1 = require("./generic");
@@ -41,6 +42,7 @@ const allStyles = [
     newKid_1.newKidStyle,
     monk_1.monkStyle,
     rogue_1.rogueStyle,
+    juggalo_1.juggaloStyle,
     ropeADope_1.ropeADopeStyle,
     workTheBody_1.workTheBodyStyle,
     barbarian_1.barbarianStyle,

--- a/serverBuild/styles/juggalo.js
+++ b/serverBuild/styles/juggalo.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.juggaloStyle = {
+    name: 'Juggalo',
+    description: "We all family, whoop whoop!",
+    cards: [
+        "Stab to Death",
+        "Face Paint",
+        "Bury the Hatchet",
+        "Head Spin",
+        "Spray Faygo",
+        "Horror-Core Mosh Pit",
+        "Whoop Whoop!",
+        "Evil Clown Laughter",
+        "Psycho Babble",
+        "Boombox Blast",
+        "Gathering of Clowns",
+    ]
+};


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Juggalo

Juggalos are creepy clowns that view themselves as a giant family and enjoy murder by blade (maybe jokingly, maybe not). Also horrorcore/hip hop. The style contains a bunch of shallow references lifted from the linked wikipedia page.

Their strengths are moving and close (inspired by dancing in a mosh pit) and they don't do much if those conditions aren't met.

They bring the `spooky` tag into the game, and to my knowledge have the highest numbers of tagged cards and enhances concentrated in a single style

<img width="1426" alt="Screen Shot 2019-06-23 at 1 07 23 PM" src="https://user-images.githubusercontent.com/8185120/59981468-7458ab80-95b8-11e9-823f-22f5c3a8aa3a.png">
<img width="1425" alt="Screen Shot 2019-06-23 at 1 07 35 PM" src="https://user-images.githubusercontent.com/8185120/59981471-77539c00-95b8-11e9-9635-941e5090b871.png">

